### PR TITLE
Fixed a file loading on Opera browser

### DIFF
--- a/load-image.js
+++ b/load-image.js
@@ -37,7 +37,7 @@
             } else {
                 url = file;
             }
-            if (url) {
+            if (url && !(window.File && url instanceof File)) {
                 img.src = url;
                 return img;
             } else {
@@ -92,7 +92,7 @@
     };
 
     loadImage.revokeObjectURL = function (url) {
-        return urlAPI ? urlAPI.revokeObjectURL(url) : false;
+        return urlAPI && typeof urlAPI.revokeObjectURL !== 'undefined' ? urlAPI.revokeObjectURL(url) : false;
     };
 
     // Loads a given File object via FileReader interface,


### PR DESCRIPTION
On Opera browser, File object passed to the window.URL.createObjectURL() and returns File object.
Will be `<img src="[object File]"/>` created by set a File object to img.src.

One more, revokeObjectURL() is not implemented on Opera browser.
