### PR TITLE
Added the option 'nounload'

### DIFF
--- a/load-image.js
+++ b/load-image.js
@@ -24,7 +24,7 @@
                 oUrl;
             img.onerror = callback;
             img.onload = function () {
-                if (oUrl) {
+                if (oUrl && !options.nounload) {
                     loadImage.revokeObjectURL(oUrl);
                 }
                 callback(loadImage.scale(img, options));


### PR DESCRIPTION
If the image data was loaded into an object URL, this option prevents it from
being unloaded once the image is ready.
