### PR TITLE
Multiple errors for non blob files - fixed 

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,9 +84,10 @@
                     (e.dataTransfer || e.target).files[0],
                     function (img) {
                         if (!(img.src || img instanceof HTMLCanvasElement)) {
-                            img = $(
+                            img = $('<p>'+
                                 '<span class="label label-important">Error</span>' +
-                                    ' <span>Loading image file failed</span>'
+                                    ' <span>Loading image file failed</span>'+
+									'</p>
                             );
                         }
                         result.children().replaceWith(img);


### PR DESCRIPTION
fixed multiple error prompts when uploading non blob files
This is a fix for issue #20
