### PR TITLE
browserify support

### DIFF
--- a/js/load-image.js
+++ b/js/load-image.js
@@ -298,4 +298,4 @@
     } else {
         $.loadImage = loadImage;
     }
-}(this));
+}(window));


### PR DESCRIPTION
In a browserify package, this will refer to a node-style exports object, not
window. So just reference window directly.