### PR TITLE
Exposing license information according to bower format

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -36,12 +36,7 @@
     "url": "git://github.com/blueimp/JavaScript-Load-Image.git"
   },
   "bugs": "https://github.com/blueimp/JavaScript-Load-Image/issues",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://www.opensource.org/licenses/MIT"
-    }
-  ],
+  "license": "MIT",
   "main": [
     "js/load-image.js",
     "js/load-image-ios.js",


### PR DESCRIPTION
`license` field should contain String or Array of Strings. See: http://bower.io/docs/creating-packages/

Current format doesn't work with libraries that inspect and generate information about all the libraries used in the project (e.g. `grunt-license-bower`).