### PR TITLE
added the main key to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,5 +42,6 @@
     "grunt-contrib-uglify": "~0.5.1",
     "grunt-contrib-jshint": "~0.10.0",
     "grunt-bump-build-git": "~1.1.1"
-  }
+  },
+  "main": "js/load-image.js"
 }


### PR DESCRIPTION
It is easier to integrate the library with the npm because as far as I know npm looksup the "main" key in package.json to load the right files.