### PR TITLE
Downsample in 2x steps for better image quality

### DIFF
--- a/js/load-image.js
+++ b/js/load-image.js
@@ -242,24 +242,60 @@
             }
         }
         if (useCanvas) {
-            canvas.width = destWidth;
-            canvas.height = destHeight;
-            loadImage.transformCoordinates(
-                canvas,
-                options
-            );
-            return loadImage.renderImageToCanvas(
-                canvas,
-                img,
-                sourceX,
-                sourceY,
-                sourceWidth,
-                sourceHeight,
-                0,
-                0,
-                destWidth,
-                destHeight
-            );
+            if (destWidth < sourceWidth && destHeight < sourceHeight) {
+                var stepScale = 0.5;
+                canvas.width = sourceWidth;
+                canvas.height = sourceHeight;
+
+                while (canvas.width > destWidth) {
+                    if (canvas.width * stepScale > destWidth) {
+                        canvas.width = canvas.width * stepScale;
+                        canvas.height = canvas.height * stepScale;
+                    } else {
+                        canvas.width = destWidth;
+                        canvas.height = destHeight;
+                    }
+                    loadImage.transformCoordinates(
+                        canvas,
+                        options
+                    );
+                    canvas = loadImage.renderImageToCanvas(
+                        canvas,
+                        img,
+                        sourceX,
+                        sourceY,
+                        sourceWidth,
+                        sourceHeight,
+                        0,
+                        0,
+                        canvas.width,
+                        canvas.height
+                    );
+                    img = new Image();
+                    img.src = canvas.toDataURL();
+                    sourceWidth = canvas.width;
+                    sourceHeight = canvas.height;
+                }
+            } else {
+                canvas.width = destWidth;
+                canvas.height = destHeight;
+                loadImage.transformCoordinates(
+                    canvas,
+                    options
+                );
+                return loadImage.renderImageToCanvas(
+                    canvas,
+                    img,
+                    sourceX,
+                    sourceY,
+                    sourceWidth,
+                    sourceHeight,
+                    0,
+                    0,
+                    destWidth,
+                    destHeight
+                );
+            }
         }
         img.width = destWidth;
         img.height = destHeight;


### PR DESCRIPTION
Downsampling images is inconsistent between browsers, some results are horrible. Solutions seems to be to downsample by scaling images to half the size until destination size is achieved. Perhaps an option could be added to disable steps or test browser downsampling strategy if/when possible. Overhead for resizing is minimal because image gets smaller very fast.

See: http://stackoverflow.com/questions/17861447/html5-canvas-drawimage-how-to-apply-antialiasing
Needed for: https://github.com/concrete5/concrete5/issues/3408