### PR TITLE
use relative path for AMD

### DIFF
--- a/js/load-image-exif-map.js
+++ b/js/load-image-exif-map.js
@@ -18,7 +18,7 @@
     'use strict';
     if (typeof define === 'function' && define.amd) {
         // Register as an anonymous AMD module:
-        define(['load-image', 'load-image-exif'], factory);
+        define(['./load-image', './load-image-exif'], factory);
     } else if (typeof module === 'object' && module.exports) {
         factory(require('./load-image'), require('./load-image-exif'));
     } else {

--- a/js/load-image-exif.js
+++ b/js/load-image-exif.js
@@ -15,7 +15,7 @@
     'use strict';
     if (typeof define === 'function' && define.amd) {
         // Register as an anonymous AMD module:
-        define(['load-image', 'load-image-meta'], factory);
+        define(['./load-image', './load-image-meta'], factory);
     } else if (typeof module === 'object' && module.exports) {
         factory(require('./load-image'), require('./load-image-meta'));
     } else {

--- a/js/load-image-ios.js
+++ b/js/load-image-ios.js
@@ -19,7 +19,7 @@
     'use strict';
     if (typeof define === 'function' && define.amd) {
         // Register as an anonymous AMD module:
-        define(['load-image'], factory);
+        define(['./load-image'], factory);
     } else if (typeof module === 'object' && module.exports) {
         factory(require('./load-image'));
     } else {

--- a/js/load-image-meta.js
+++ b/js/load-image-meta.js
@@ -19,7 +19,7 @@
     'use strict';
     if (typeof define === 'function' && define.amd) {
         // Register as an anonymous AMD module:
-        define(['load-image'], factory);
+        define(['./load-image'], factory);
     } else if (typeof module === 'object' && module.exports) {
         factory(require('./load-image'));
     } else {

--- a/js/load-image-orientation.js
+++ b/js/load-image-orientation.js
@@ -15,7 +15,7 @@
     'use strict';
     if (typeof define === 'function' && define.amd) {
         // Register as an anonymous AMD module:
-        define(['load-image'], factory);
+        define(['./load-image'], factory);
     } else if (typeof module === 'object' && module.exports) {
         factory(require('./load-image'));
     } else {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
     "mocha-phantomjs": "4.0.1",
     "uglify-js": "2.6.1"
   },
+  "directories" : {
+    "lib" : "js"
+  },
   "scripts": {
     "test": "jshint js test && mocha-phantomjs test/index.html",
     "build": "cd js && uglifyjs load-image.js load-image-ios.js load-image-orientation.js load-image-meta.js load-image-exif.js load-image-exif-map.js -c -m -o load-image.all.min.js --source-map load-image.all.min.js.map",


### PR DESCRIPTION
webpack fails to resolve because `.` is not in the resolve path by default. This patch can fix it.

```pain
ERROR in ./~/blueimp-load-image/js/load-image-meta.js
Module not found: Error: Can't resolve 'load-image' in '/Users/monson/project/eleapp/node_modules/blueimp-load-image/js'
resolve 'load-image' in '/Users/monson/project/eleapp/node_modules/blueimp-load-image/js'
  Parsed request is a module
  using description file: /Users/monson/project/eleapp/node_modules/blueimp-load-image/package.json (relative path: ./js)
    Field 'browser' doesn't contain a valid alias configuration
  after using description file: /Users/monson/project/eleapp/node_modules/blueimp-load-image/package.json (relative path: ./js)
    resolve as module
      /Users/monson/project/eleapp/node_modules/node_modules doesn't exist or is not a directory
      /Users/monson/project/node_modules doesn't exist or is not a directory
      /Users/monson/node_modules doesn't exist or is not a directory
      /Users/node_modules doesn't exist or is not a directory
      /node_modules doesn't exist or is not a directory
      /Users/monson/project/eleapp/node_modules/blueimp-load-image/js/node_modules doesn't exist or is not a directory
      /Users/monson/project/eleapp/node_modules/blueimp-load-image/node_modules doesn't exist or is not a directory
      looking for modules in /Users/monson/project/eleapp/node_modules
        using description file: /Users/monson/project/eleapp/package.json (relative path: ./node_modules)
          Field 'browser' doesn't contain a valid alias configuration
        after using description file: /Users/monson/project/eleapp/package.json (relative path: ./node_modules)
          using description file: /Users/monson/project/eleapp/package.json (relative path: ./node_modules/load-image)
            as directory
              /Users/monson/project/eleapp/node_modules/load-image doesn't exist
            no extension
              Field 'browser' doesn't contain a valid alias configuration
              /Users/monson/project/eleapp/node_modules/load-image doesn't exist
            Field 'browser' doesn't contain a valid alias configuration
            /Users/monson/project/eleapp/node_modules/load-image doesn't exist
            .js
              Field 'browser' doesn't contain a valid alias configuration
              /Users/monson/project/eleapp/node_modules/load-image.js doesn't exist
            .jsx
              Field 'browser' doesn't contain a valid alias configuration
              /Users/monson/project/eleapp/node_modules/load-image.jsx doesn't exist
[/Users/monson/project/eleapp/node_modules/node_modules]
[/Users/monson/project/node_modules]
[/Users/monson/node_modules]
[/Users/node_modules]
[/node_modules]
[/Users/monson/project/eleapp/node_modules/blueimp-load-image/js/node_modules]
[/Users/monson/project/eleapp/node_modules/blueimp-load-image/node_modules]
[/Users/monson/project/eleapp/node_modules/load-image]
[/Users/monson/project/eleapp/node_modules/load-image]
[/Users/monson/project/eleapp/node_modules/load-image]
[/Users/monson/project/eleapp/node_modules/load-image.js]
[/Users/monson/project/eleapp/node_modules/load-image.jsx]
 @ ./~/blueimp-load-image/js/load-image-meta.js 22:8-39
```