### PR TITLE
Fix for avoid build issue for browser

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
-module.exports = require('./js/load-image')
-
-require('./js/load-image-exif')
-require('./js/load-image-exif-map')
-require('./js/load-image-meta')
-require('./js/load-image-orientation')
+if (typeof module === 'object' && module.exports) {
+   module.exports = require('./js/load-image')
+   require('./js/load-image-exif')
+   require('./js/load-image-exif-map')
+   require('./js/load-image-meta')
+   require('./js/load-image-orientation')
+}


### PR DESCRIPTION
verify if the code is to build for nodeJs or for the browser. If the library is built and minified for the browser, the NodeJS code in index.js will not be added because module.exports cannot interpreted by the browser.