### PR TITLE
Adding bower file. Required to get it work with gulp and uglifyer

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,37 @@
+{
+  "name": "blueimp-load-image",
+  "description": "JavaScript Load Image is a library to load images provided as File or Blob objects or via URL. It returns an optionally scaled and/or cropped HTML img or canvas element. It also provides a method to parse image meta data to extract Exif tags and thumbnails and to restore the complete image header after resizing.",
+  "main": [
+    "js/load-image",
+    "js/load-image-exif",
+    "js/load-image-exif-map",
+    "js/load-image-meta",
+    "js/load-image-orientation"
+  ],
+  "license": "MIT",
+  "keywords": [
+    "javascript",
+    "load",
+    "loading",
+    "image",
+    "file",
+    "blob",
+    "url",
+    "scale",
+    "crop",
+    "img",
+    "canvas",
+    "meta",
+    "exif",
+    "thumbnail",
+    "resizing"
+  ],
+  "homepage": "https://github.com/blueimp/JavaScript-Load-Image",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
Without an bower file, bower detects the index.js in the root as main file. 