### PR TITLE
fix when Exif attribute value is undefined

### DIFF
--- a/js/load-image-exif-map.js
+++ b/js/load-image-exif-map.js
@@ -323,6 +323,11 @@
 
   loadImage.ExifMap.prototype.getText = function (id) {
     var value = this.get(id)
+    
+    if (value==undefined) {
+      return ""
+    }
+    
     switch (id) {
       case 'LightSource':
       case 'Flash':


### PR DESCRIPTION
 I have a JPG that has a GPSVersionID id but the value is undefined.

The error I receive is:
Uncaught TypeError: Cannot read property '0' of undefined

This code simply returns an empty string when the value is undefined.