### PR TITLE
fix(package): main should reference index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blueimp-load-image",
   "version": "2.8.1",
-  "main": "js/load-image.js",
+  "main": "index.js",
   "title": "JavaScript Load Image",
   "description": "JavaScript Load Image is a library to load images provided as File or Blob objects or via URL. It returns an optionally scaled and/or cropped HTML img or canvas element. It also provides a method to parse image meta data to extract Exif tags and thumbnails and to restore the complete image header after resizing.",
   "keywords": [


### PR DESCRIPTION
It looks like the recent change at https://github.com/blueimp/JavaScript-Load-Image/commit/b1bf512606f00690aefe7b756888e1ed8df4860e#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R4 means that you now have use `loadImage = require('blueimp-load-image/index.js')` instead of `loadImage = require('blueimp-load-image')`

Thanks for the great lib!