### PR TITLE
fix crop with downsamplingRatio

### DIFF
--- a/js/load-image.js
+++ b/js/load-image.js
@@ -285,6 +285,8 @@
             canvas.width,
             canvas.height
           )
+          sourceX = 0
+          sourceY = 0
           sourceWidth = canvas.width
           sourceHeight = canvas.height
           img = document.createElement('canvas')

--- a/test/test.js
+++ b/test/test.js
@@ -336,6 +336,23 @@
         done()
       }, {sourceWidth: 40, sourceHeight: 40, crop: true, pixelRatio: 2})).to.be.ok
     })
+
+    it('Crop using maxWidth/maxHeight with the given downsamplingRatio', function (done) {
+      expect(loadImage(blobGIF, function (img) {
+        expect(img.width).to.equal(10)
+        expect(img.height).to.equal(10)
+
+        var data = img.getContext('2d').getImageData(0, 0, 10, 10).data
+        for (var i = 0; i < data.length / 4; i += 4) {
+          expect(data[i]).to.equal(0)
+          expect(data[i + 1]).to.equal(0)
+          expect(data[i + 2]).to.equal(0)
+          expect(data[i + 3]).to.equal(255)
+        }
+
+        done()
+      }, {maxWidth: 10, maxHeight: 10, crop: true, downsamplingRatio: 0.5})).to.be.ok
+    })
   })
 
   describe('Orientation', function () {


### PR DESCRIPTION
It not actually broken, because I can't get canvas data (Tainted canvases may not be exported).
I append cropped image to body, and it transparent, but it should be black.

I think, bug in [renderImageToCanvas](https://github.com/blueimp/JavaScript-Load-Image/blob/master/js/load-image.js#L279-L280) calling with non-zero `sourceX` and `sourceY` in cycle, and image just moving out beyond the border of canvas.

If you agree, I can fix it, but I don't know how to check content of cropped image in test