### PR TITLE
Fix import from Node environment (to not break in server side rendering)

### DIFF
--- a/js/load-image-fetch.js
+++ b/js/load-image-fetch.js
@@ -25,7 +25,7 @@
 }(function (loadImage) {
   'use strict'
 
-  if ('fetch' in window && 'Request' in window) {
+  if (typeof fetch !== 'undefined' && typeof Request !== 'undefined') {
     loadImage.fetchBlob = function (url, callback, options) {
       if (loadImage.hasMetaOption(options)) {
         return fetch(new Request(url, options)).then(function (response) {

--- a/js/load-image-meta.js
+++ b/js/load-image-meta.js
@@ -29,7 +29,7 @@
 }(function (loadImage) {
   'use strict'
 
-  var hasblobSlice = window.Blob && (Blob.prototype.slice ||
+  var hasblobSlice = typeof Blob !== 'undefined' && (Blob.prototype.slice ||
   Blob.prototype.webkitSlice || Blob.prototype.mozSlice)
 
   loadImage.blobSlice = hasblobSlice && function () {
@@ -55,7 +55,7 @@
     var that = this
     // 256 KiB should contain all EXIF/ICC/IPTC segments:
     var maxMetaDataSize = options.maxMetaDataSize || 262144
-    var noMetaData = !(window.DataView && file && file.size >= 12 &&
+    var noMetaData = !(typeof DataView !== 'undefined' && file && file.size >= 12 &&
                       file.type === 'image/jpeg' && loadImage.blobSlice)
     if (noMetaData || !loadImage.readFile(
         loadImage.blobSlice.call(file, 0, maxMetaDataSize),

--- a/js/load-image.js
+++ b/js/load-image.js
@@ -61,9 +61,9 @@
   }
   // The check for URL.revokeObjectURL fixes an issue with Opera 12,
   // which provides URL.createObjectURL but doesn't properly implement it:
-  var urlAPI = (typeof createObjectURL !== 'undefined' && createObjectURL) ||
-                (typeof URL !== 'undefined' && URL.revokeObjectURL && URL) ||
-                (typeof webkitURL !== 'undefined' && webkitURL)
+  var urlAPI = ($.createObjectURL && $) ||
+                ($.URL && URL.revokeObjectURL && URL) ||
+                ($.webkitURL && webkitURL)
 
   function revokeHelper (img, options) {
     if (img._objectURL && !(options && options.noRevoke)) {

--- a/js/load-image.js
+++ b/js/load-image.js
@@ -61,9 +61,9 @@
   }
   // The check for URL.revokeObjectURL fixes an issue with Opera 12,
   // which provides URL.createObjectURL but doesn't properly implement it:
-  var urlAPI = (window.createObjectURL && window) ||
-                (window.URL && URL.revokeObjectURL && URL) ||
-                (window.webkitURL && webkitURL)
+  var urlAPI = (typeof createObjectURL !== 'undefined' && createObjectURL) ||
+                (typeof URL !== 'undefined' && URL.revokeObjectURL && URL) ||
+                (typeof webkitURL !== 'undefined' && webkitURL)
 
   function revokeHelper (img, options) {
     if (img._objectURL && !(options && options.noRevoke)) {
@@ -135,4 +135,4 @@
   } else {
     $.loadImage = loadImage
   }
-}(window))
+}(this))


### PR DESCRIPTION
the library is breaking in Node environment with a `window is not defined` – not at runtime, but at import time. that PR fixes this.

my only usecase is to have the library working with Server Side Rendering (in context of react). (in my case, the library don't actually gets used in Node, but it's still imported and embedded in the server bundle that will break before this PR)