### PR TITLE
Compatibility with jQuery 3.5.0

### DIFF
--- a/js/demo/demo.js
+++ b/js/demo/demo.js
@@ -29,7 +29,7 @@ $(function () {
    * @param {object} tags Tags object
    */
   function displayTagData(node, tags) {
-    var table = $('<table>')
+    var table = $('<table></table>')
     var row = $('<tr></tr>')
     var cell = $('<td></td>')
     var prop
@@ -59,7 +59,7 @@ $(function () {
    */
   function displayThumbnailImage(node, thumbnail, options) {
     if (thumbnail) {
-      var link = $('<a>')
+      var link = $('<a></a>')
         .attr('href', loadImage.createObjectURL(thumbnail))
         .attr('download', 'thumbnail.jpg')
         .appendTo(node)
@@ -105,7 +105,7 @@ $(function () {
       result.children().replaceWith($('<span>Loading image file failed</span>'))
       return
     }
-    var content = $('<a>').append(img)
+    var content = $('<a></a>').append(img)
     result.children().replaceWith(content)
     if (data) {
       if (img.getContext) {

--- a/js/vendor/jquery.Jcrop.js
+++ b/js/vendor/jquery.Jcrop.js
@@ -329,7 +329,7 @@
         boundy = $img.height(),
         
         
-        $div = $('<div />').width(boundx).height(boundy).addClass(cssClass('holder')).css({
+        $div = $('<div></div>').width(boundx).height(boundy).addClass(cssClass('holder')).css({
         position: 'relative',
         backgroundColor: options.bgColor
       }).insertAfter($origimg).append($img);
@@ -338,19 +338,19 @@
       $div.addClass(options.addClass);
     }
 
-    var $img2 = $('<div />'),
+    var $img2 = $('<div></div>'),
 
-        $img_holder = $('<div />') 
+        $img_holder = $('<div></div>')
         .width('100%').height('100%').css({
           zIndex: 310,
           position: 'absolute',
           overflow: 'hidden'
         }),
 
-        $hdl_holder = $('<div />') 
+        $hdl_holder = $('<div></div>')
         .width('100%').height('100%').css('zIndex', 320), 
 
-        $sel = $('<div />') 
+        $sel = $('<div></div>')
         .css({
           position: 'absolute',
           zIndex: 600
@@ -737,7 +737,7 @@
     // Shade Module {{{
     var Shade = (function() {
       var enabled = false,
-          holder = $('<div />').css({
+          holder = $('<div></div>').css({
             position: 'absolute',
             zIndex: 240,
             opacity: 0
@@ -779,7 +779,7 @@
         });
       }
       function createShade() {
-        return $('<div />').css({
+        return $('<div></div>').css({
           position: 'absolute',
           backgroundColor: options.shadeColor||options.bgColor
         }).appendTo(holder);
@@ -863,7 +863,7 @@
       // Private Methods
       function insertBorder(type) //{{{
       {
-        var jq = $('<div />').css({
+        var jq = $('<div></div>').css({
           position: 'absolute',
           opacity: options.borderOpacity
         }).addClass(cssClass(type));
@@ -873,7 +873,7 @@
       //}}}
       function dragDiv(ord, zi) //{{{
       {
-        var jq = $('<div />').mousedown(createDragger(ord)).css({
+        var jq = $('<div></div>').mousedown(createDragger(ord)).css({
           cursor: ord + '-resize',
           position: 'absolute',
           zIndex: zi
@@ -1226,7 +1226,7 @@
         width: '12px'
       }).addClass('jcrop-keymgr'),
 
-        $keywrap = $('<div />').css({
+        $keywrap = $('<div></div>').css({
           position: 'absolute',
           overflow: 'hidden'
         }).append($keymgr);


### PR DESCRIPTION
Usages like `$('<div/>')` must be changed to `$('<div></div>')`

See the blog post:
https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/
and the upgrade guide for more details:
https://jquery.com/upgrade-guide/3.5/